### PR TITLE
Example in which tests fails for instantiated Plugin Entry

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     dependencies {
         // The gradle plugin and the maven plugin have to be updated after each version of Android
         // studio comes out
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }

--- a/test/android/app/src/androidTest/java/org/apache/cordova/unittests/ExternalPluginTest.java
+++ b/test/android/app/src/androidTest/java/org/apache/cordova/unittests/ExternalPluginTest.java
@@ -1,0 +1,60 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova.unittests;
+
+import android.content.Intent;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+
+import org.apache.cordova.engine.SystemWebView;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class ExternalPluginTest {
+
+    private static final String FALSE_URI = "http://www.google.com";
+
+    @Rule
+    public ActivityTestRule mActivityRule = new ActivityTestRule<>(
+            ExternalPluginActivity.class, true, false
+    );
+
+    @Before
+    public void launchApplicationWithIntent() {
+        Intent intent = new Intent();
+        mActivityRule.launchActivity(intent);
+    }
+
+
+    @Test
+    public void webViewCheck() {
+        ExternalPluginActivity activity = (ExternalPluginActivity) mActivityRule.getActivity();
+        //Fish the webview out of the mostly locked down Activity using the Android SDK
+        View view = activity.getWindow().getCurrentFocus();
+        assertEquals(SystemWebView.class, view.getClass());
+    }
+
+}

--- a/test/android/app/src/main/AndroidManifest.xml
+++ b/test/android/app/src/main/AndroidManifest.xml
@@ -53,6 +53,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ExternalPluginActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:label="@string/app_name"
+            android:windowSoftInputMode="adjustPan">
+            <intent-filter >
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/test/android/app/src/main/java/org/apache/cordova/unittests/ExternalPlugin.java
+++ b/test/android/app/src/main/java/org/apache/cordova/unittests/ExternalPlugin.java
@@ -1,0 +1,44 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.unittests;
+
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.LOG;
+
+public class ExternalPlugin extends CordovaPlugin {
+
+    static String TAG = "ExternalPlugin";
+
+    @Override
+    public void onStart() {
+        LOG.d(TAG, "onStart");
+    }
+    @Override
+    public void onPause(boolean multitasking) {
+        LOG.d(TAG, "onPause");
+    }
+    @Override
+    public void onResume(boolean multitasking) {
+        LOG.d(TAG, "onResume");
+    }
+    @Override
+    public void onStop() {
+        LOG.d(TAG, "onStop");
+    }
+}

--- a/test/android/app/src/main/java/org/apache/cordova/unittests/ExternalPluginActivity.java
+++ b/test/android/app/src/main/java/org/apache/cordova/unittests/ExternalPluginActivity.java
@@ -1,0 +1,39 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+package org.apache.cordova.unittests;
+
+import android.os.Bundle;
+
+import org.apache.cordova.CordovaActivity;
+import org.apache.cordova.PluginEntry;
+
+public class ExternalPluginActivity extends CordovaActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+        PluginEntry externalPlugin = new PluginEntry("external_plugin", new ExternalPlugin());
+        pluginEntries.add(externalPlugin);
+
+        // Set by <content src="index.html" /> in config.xml
+        loadUrl(launchUrl);
+    }
+}

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
### Platforms affected
Android

https://github.com/apache/cordova-android/issues/1164
### Testing
Just run test



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
